### PR TITLE
Fixes `showDeniedAlert()` in `requestEvents()`

### DIFF
--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -591,7 +591,7 @@ public class PermissionScope: UIViewController, CLLocationManagerDelegate, UIGes
                     self.detectAndCallback()
             })
         case .Unauthorized:
-            self.showDeniedAlert(.Reminders)
+            self.showDeniedAlert(.Events)
         default:
             break
         }


### PR DESCRIPTION
Previously it was calling it with `.Reminders`, although it should
obviously call that with `.Events`
