### PR TITLE
Add Objective-C Compatibility. Swift still works the same.

### DIFF
--- a/PermissionScope-example/ViewController.swift
+++ b/PermissionScope-example/ViewController.swift
@@ -59,6 +59,19 @@ class ViewController: UIViewController {
         }, cancelled: { (results) -> Void in
             println("thing was cancelled")
         })
+        
+        
+        /* 
+         * This is what it would look like in Objective-C :
+        
+        [multiPscope showWithAuthChange:^(BOOL finished, NSArray * __null_unspecified results) {
+        NSLog(@"changed results are: %@", results);
+        
+        } cancelled:^(NSArray * __null_unspecified results) {
+        NSLog(@"thing was cancelled");
+        }];
+
+        */
     }
 }
 

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -348,7 +348,6 @@ extension String {
             button.setTitle("Allow \(type.stringValue())".localized.uppercaseString, forState: UIControlState.Normal)
         }
         
-        println("SETTING TARGET: request\(type.stringValue())")
         button.addTarget(self, action: Selector("request\(type.stringValue())"), forControlEvents: UIControlEvents.TouchUpInside)
         
         return button
@@ -407,7 +406,6 @@ extension String {
     }
     
     public func requestLocationAlways() {
-        println("LOCATION ALWAYS METHOD CALLED status: \(statusLocationAlways().stringValue())" )
         switch statusLocationAlways() {
         case .Unknown:
             if CLLocationManager.authorizationStatus() == .AuthorizedWhenInUse {
@@ -503,8 +501,6 @@ extension String {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("finishedShowingNotificationPermission"), name: UIApplicationDidBecomeActiveNotification, object: nil)
         notificationTimer?.invalidate()
-        
-        println("showing notification permission")
     }
     
     var notificationTimer : NSTimer?
@@ -804,7 +800,6 @@ extension String {
     }
     
     func showDeniedAlert(permission: PermissionType) {
-        println("showing denied")
         
         var alert = UIAlertController(title: "Permission for \(permission.prettyName()) was denied.",
             message: "Please enable access to \(permission.prettyName()) in the App's Settings",
@@ -823,7 +818,6 @@ extension String {
     }
     
     func showDisabledAlert(permission: PermissionType) {
-        println("showing disabled")
         
         var alert = UIAlertController(title: "\(permission.prettyName()) is currently disabled.",
             message: "Please enable access to \(permission.prettyName()) in Settings",

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -84,7 +84,6 @@ public class PermissionConfig : NSObject {
     public init(type: PermissionType, demands: PermissionDemands, message: String, notificationCategories: Set<UIUserNotificationCategory>? = .None) {
         
         if type != .Notifications && notificationCategories != .None {
-            println("NOT NONE")
             assertionFailure("notificationCategories only apply to the .Notifications permission")
         }
         
@@ -190,7 +189,6 @@ extension String {
         
         // defaults.removeObjectForKey(PermissionScopeAskedForNotificationsDefaultsKey)
         
-        println(baseView)
         // Set up main view
         view.frame = UIScreen.mainScreen().bounds
         view.autoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth
@@ -235,8 +233,6 @@ extension String {
         closeButton.addTarget(self, action: Selector("cancel"), forControlEvents: UIControlEvents.TouchUpInside)
         
         contentView.addSubview(closeButton)
-        
-        println(baseView)
     }
     
     public convenience init() {
@@ -517,15 +513,11 @@ extension String {
         }
         
         if let notificationResult : PermissionResult = allResults.first {
-            println("NOTIFICATION result: \(allResults.first?.type.stringValue())")
-            
             if notificationResult.status == PermissionStatus.Unknown {
                 showDeniedAlert(notificationResult.type)
             } else {
                 detectAndCallback()
             }
-        } else {
-            println("NOTIFICATION DIDN'T INSTANTIATE")
         }
     }
     


### PR DESCRIPTION
PermissionScope now works with Objective-C!!

I'm using it in one of my projects and it now works with Objective-C classes. The example project in Swift still works the same way with the new changes. 

Major things were changing the Swift enums to be Ints and then just adding a stringValue method, declaring the authChange and cancel struct parameters as implicitly unwrapped optionals, and adding the @ objc attribute to some methods.
