### PR TITLE
HealthKit and CloudKit

### DIFF
--- a/PermissionScope-example/AppDelegate.swift
+++ b/PermissionScope-example/AppDelegate.swift
@@ -16,9 +16,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
-        
-        print("currentNotificationSettings: \(UIApplication.sharedApplication().currentUserNotificationSettings())")
-        
         return true
     }
 

--- a/PermissionScope-example/ViewController.swift
+++ b/PermissionScope-example/ViewController.swift
@@ -7,9 +7,7 @@
 //
 
 import UIKit
-import CoreAudio
 import PermissionScope
-import HealthKit
 
 class ViewController: UIViewController {
     let singlePscope = PermissionScope()
@@ -22,25 +20,26 @@ class ViewController: UIViewController {
         singlePscope.addPermission(NotificationsPermissionConfig(
             message: "We use this to send you\r\nspam and love notes",
             notificationCategories: .None))
+        
         multiPscope.addPermission(ContactsPermissionConfig(
             message: "We use this to steal\r\nyour friends"))
         multiPscope.addPermission(NotificationsPermissionConfig(
             message: "We use this to send you\r\nspam and love notes",
             notificationCategories: .None))
-//        multiPscope.addPermission(LocationWhileInUsePermissionConfig(
-//            message: "We use this to track\r\nwhere you live"))
-        multiPscope.addPermission(HealthPermissionConfig(message: "We need your health data\r\nto know you better",
-            healthTypesToShare: [
-                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMassIndex)!,
-                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMass)!,
-                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierHeight)!
-                ],
-            healthTypesToRead: [
-                HKObjectType.characteristicTypeForIdentifier(HKCharacteristicTypeIdentifierDateOfBirth)!,
-                HKObjectType.characteristicTypeForIdentifier(HKCharacteristicTypeIdentifierBiologicalSex)!,
-                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMass)!,
-                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierHeight)!
-                ]))
+        multiPscope.addPermission(LocationWhileInUsePermissionConfig(
+            message: "We use this to track\r\nwhere you live"))
+//        multiPscope.addPermission(HealthPermissionConfig(message: "We need your health data\r\nto know you better",
+//            healthTypesToShare: [
+//                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMassIndex)!,
+//                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMass)!,
+//                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierHeight)!
+//                ],
+//            healthTypesToRead: [
+//                HKObjectType.characteristicTypeForIdentifier(HKCharacteristicTypeIdentifierDateOfBirth)!,
+//                HKObjectType.characteristicTypeForIdentifier(HKCharacteristicTypeIdentifierBiologicalSex)!,
+//                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMass)!,
+//                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierHeight)!
+//                ]))
         
         // Other example permissions
         //        multiPscope.addPermission(PermissionConfig(type: .Bluetooth, demands: .Required, message: "We use this to drain your battery"))

--- a/PermissionScope-example/ViewController.swift
+++ b/PermissionScope-example/ViewController.swift
@@ -52,10 +52,10 @@ class ViewController: UIViewController {
     @IBAction func singlePerm() {
         singlePscope.show(
             { (finished, results) -> Void in
-                print("got results \(results)", appendNewline: true)
+                print("got results \(results)")
             },
             cancelled: { (results) -> Void in
-                print("thing was cancelled", appendNewline: true)
+                print("thing was cancelled")
             }
         )
     }
@@ -63,10 +63,10 @@ class ViewController: UIViewController {
     @IBAction func multiPerms() {
         multiPscope.show(
             { (finished, results) -> Void in
-                print("got results \(results)", appendNewline: true)
+                print("got results \(results)")
             },
             cancelled: { (results) -> Void in
-                print("thing was cancelled", appendNewline: true)
+                print("thing was cancelled")
             }
         )
     }

--- a/PermissionScope-example/ViewController.swift
+++ b/PermissionScope-example/ViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import CoreAudio
 import PermissionScope
+import HealthKit
 
 class ViewController: UIViewController {
     let singlePscope = PermissionScope()
@@ -18,20 +19,28 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         
-        singlePscope.addPermission(PermissionConfig(type: .Notifications,
-            demands: .Required,
+        singlePscope.addPermission(NotificationsPermissionConfig(
             message: "We use this to send you\r\nspam and love notes",
             notificationCategories: .None))
-        
-        multiPscope.addPermission(PermissionConfig(type: .Contacts,
-            demands: .Required,
+        multiPscope.addPermission(ContactsPermissionConfig(
             message: "We use this to steal\r\nyour friends"))
-        multiPscope.addPermission(PermissionConfig(type: .Notifications,
-            demands: .Required,
-            message: "We use this to send you\r\nspam and love notes", notificationCategories: .None))
-        multiPscope.addPermission(PermissionConfig(type: .LocationInUse,
-            demands: .Required,
-            message: "We use this to track\r\nwhere you live"))
+        multiPscope.addPermission(NotificationsPermissionConfig(
+            message: "We use this to send you\r\nspam and love notes",
+            notificationCategories: .None))
+//        multiPscope.addPermission(LocationWhileInUsePermissionConfig(
+//            message: "We use this to track\r\nwhere you live"))
+        multiPscope.addPermission(HealthPermissionConfig(message: "We need your health data\r\nto know you better",
+            healthTypesToShare: [
+                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMassIndex)!,
+                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMass)!,
+                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierHeight)!
+                ],
+            healthTypesToRead: [
+                HKObjectType.characteristicTypeForIdentifier(HKCharacteristicTypeIdentifierDateOfBirth)!,
+                HKObjectType.characteristicTypeForIdentifier(HKCharacteristicTypeIdentifierBiologicalSex)!,
+                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierBodyMass)!,
+                HKObjectType.quantityTypeForIdentifier(HKQuantityTypeIdentifierHeight)!
+                ]))
         
         // Other example permissions
         //        multiPscope.addPermission(PermissionConfig(type: .Bluetooth, demands: .Required, message: "We use this to drain your battery"))

--- a/PermissionScope-example/ViewController.swift
+++ b/PermissionScope-example/ViewController.swift
@@ -18,11 +18,20 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         
-        singlePscope.addPermission(PermissionConfig(type: .Notifications, demands: .Required, message: "We use this to send you\r\nspam and love notes", notificationCategories: .None))
+        singlePscope.addPermission(PermissionConfig(type: .Notifications,
+            demands: .Required,
+            message: "We use this to send you\r\nspam and love notes",
+            notificationCategories: .None))
         
-        multiPscope.addPermission(PermissionConfig(type: .Contacts, demands: .Required, message: "We use this to steal\r\nyour friends"))
-        multiPscope.addPermission(PermissionConfig(type: .Notifications, demands: .Required, message: "We use this to send you\r\nspam and love notes", notificationCategories: .None))
-        multiPscope.addPermission(PermissionConfig(type: .LocationInUse, demands: .Required, message: "We use this to track\r\nwhere you live"))
+        multiPscope.addPermission(PermissionConfig(type: .Contacts,
+            demands: .Required,
+            message: "We use this to steal\r\nyour friends"))
+        multiPscope.addPermission(PermissionConfig(type: .Notifications,
+            demands: .Required, message: "We use this to send you\r\nspam and love notes",
+            notificationCategories: .None))
+        multiPscope.addPermission(PermissionConfig(type: .LocationInUse,
+            demands: .Required,
+            message: "We use this to track\r\nwhere you live"))
         
         // Other example permissions
         //        multiPscope.addPermission(PermissionConfig(type: .Bluetooth, demands: .Required, message: "We use this to drain your battery"))
@@ -52,10 +61,10 @@ class ViewController: UIViewController {
     @IBAction func singlePerm() {
         singlePscope.show(
             { (finished, results) -> Void in
-                print("got results \(results)", appendNewline: true)
+                print("got results \(results)")
             },
             cancelled: { (results) -> Void in
-                print("thing was cancelled", appendNewline: true)
+                print("thing was cancelled")
             }
         )
     }
@@ -63,10 +72,10 @@ class ViewController: UIViewController {
     @IBAction func multiPerms() {
         multiPscope.show(
             { (finished, results) -> Void in
-                print("got results \(results)", appendNewline: true)
+                print("got results \(results)")
             },
             cancelled: { (results) -> Void in
-                print("thing was cancelled", appendNewline: true)
+                print("thing was cancelled")
             }
         )
     }

--- a/PermissionScope.xcodeproj/project.pbxproj
+++ b/PermissionScope.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		244B5BA81B8D5E7900FFA019 /* PermissionConfigs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244B5BA71B8D5E7900FFA019 /* PermissionConfigs.swift */; settings = {ASSET_TAGS = (); }; };
 		2487CEE11B87B01E00766A1A /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2487CEE01B87B01E00766A1A /* Extensions.swift */; };
 		2487CEE31B87B05200766A1A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2487CEE21B87B05200766A1A /* Constants.swift */; };
 		2487CEE51B87B61E00766A1A /* Structs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2487CEE41B87B61E00766A1A /* Structs.swift */; };
@@ -73,6 +74,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		244B5BA71B8D5E7900FFA019 /* PermissionConfigs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionConfigs.swift; sourceTree = "<group>"; };
 		2487CEE01B87B01E00766A1A /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		2487CEE21B87B05200766A1A /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		2487CEE41B87B61E00766A1A /* Structs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Structs.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				D092BA381AD1E5A300BFC163 /* PermissionScope.h */,
 				D092BA4F1AD1E67300BFC163 /* PermissionScope.swift */,
 				2487CEE41B87B61E00766A1A /* Structs.swift */,
+				244B5BA71B8D5E7900FFA019 /* PermissionConfigs.swift */,
 				2487CEE01B87B01E00766A1A /* Extensions.swift */,
 				2487CEE21B87B05200766A1A /* Constants.swift */,
 				D092BA361AD1E5A300BFC163 /* Supporting Files */,
@@ -382,6 +385,7 @@
 				2487CEE51B87B61E00766A1A /* Structs.swift in Sources */,
 				D092BA501AD1E67300BFC163 /* PermissionScope.swift in Sources */,
 				2487CEE11B87B01E00766A1A /* Extensions.swift in Sources */,
+				244B5BA81B8D5E7900FFA019 /* PermissionConfigs.swift in Sources */,
 				2487CEE31B87B05200766A1A /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PermissionScope/Extensions.swift
+++ b/PermissionScope/Extensions.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import HealthKit
 
 extension UIColor {
     var inverseColor: UIColor{
@@ -21,5 +22,32 @@ extension UIColor {
 extension String {
     var localized: String {
         return NSLocalizedString(self, comment: "")
+    }
+}
+
+extension SequenceType {
+    // Ty https://bigonotetaking.wordpress.com/2015/08/22/using-higher-order-methods-everywhere/
+    func first(@noescape pred: Generator.Element -> Bool) -> Generator.Element? {
+        for x in self where pred(x) { return x }
+        return nil
+    }
+}
+
+extension Optional {
+    var isNil: Bool {
+        if let _ = self {
+            return false
+        }
+        return true
+    }
+}
+
+extension HKAuthorizationStatus: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case NotDetermined: return "NotDetermined"
+        case SharingDenied: return "SharingDenied"
+        case SharingAuthorized: return "SharingAuthorized"
+        }
     }
 }

--- a/PermissionScope/Extensions.swift
+++ b/PermissionScope/Extensions.swift
@@ -10,6 +10,7 @@ import Foundation
 import HealthKit
 
 extension UIColor {
+    /// Returns the inverse color
     var inverseColor: UIColor{
         var r:CGFloat = 0.0; var g:CGFloat = 0.0; var b:CGFloat = 0.0; var a:CGFloat = 0.0;
         if self.getRed(&r, green: &g, blue: &b, alpha: &a) {
@@ -20,20 +21,28 @@ extension UIColor {
 }
 
 extension String {
+    /// NSLocalizedString shorthand
     var localized: String {
         return NSLocalizedString(self, comment: "")
     }
 }
 
 extension SequenceType {
-    // Ty https://bigonotetaking.wordpress.com/2015/08/22/using-higher-order-methods-everywhere/
-    func first(@noescape pred: Generator.Element -> Bool) -> Generator.Element? {
-        for x in self where pred(x) { return x }
+    /**
+    Returns the first that satisfies the predicate includeElement, or nil. Similar to `filter` but stops when one element is found. Thanks to [bigonotetaking](https://bigonotetaking.wordpress.com/2015/08/22/using-higher-order-methods-everywhere/)
+    
+    - parameter includeElement: Predicate that the Element must satisfy.
+    
+    - returns: First element that satisfies the predicate, or nil.
+    */
+    func first(@noescape includeElement: Generator.Element -> Bool) -> Generator.Element? {
+        for x in self where includeElement(x) { return x }
         return nil
     }
 }
 
 extension Optional {
+    /// True if the Optional is .None. Useful when if-let isn't needed.
     var isNil: Bool {
         if let _ = self {
             return false

--- a/PermissionScope/PermissionConfigs.swift
+++ b/PermissionScope/PermissionConfigs.swift
@@ -10,34 +10,24 @@ import Foundation
 import HealthKit
 import Accounts
 
+/**
+*  Protocol for permission configurations.
+*/
 @objc public protocol PermissionConfig {
+    /// Permission type
     var type: PermissionType { get }
+    /// Message for the body label of the dialog presented when requesting access.
     var message: String { get }
 }
 
 @objc public class NotificationsPermissionConfig: NSObject, PermissionConfig {
-    public let type: PermissionType
+    public let type: PermissionType = .Notifications
     public let message: String
     public let notificationCategories: Set<UIUserNotificationCategory>?
     
     public init(message: String, notificationCategories: Set<UIUserNotificationCategory>? = .None) {
         self.notificationCategories = notificationCategories
-        self.type                   = .Notifications
         self.message                = message
-    }
-}
-
-@objc public class HealthPermissionConfig: NSObject, PermissionConfig {
-    public let type: PermissionType = .HealthKit
-    public let message: String
-    public let healthTypesToShare: Set<HKSampleType>?
-    public let healthTypesToRead: Set<HKObjectType>?
-    
-    public init(message: String, healthTypesToShare: Set<HKSampleType>?,
-        healthTypesToRead: Set<HKObjectType>?) {
-            self.healthTypesToShare = healthTypesToShare
-            self.healthTypesToRead = healthTypesToRead
-            self.message = message
     }
 }
 
@@ -128,5 +118,28 @@ import Accounts
     
     public init(message: String) {
         self.message = message
+    }
+}
+
+@objc public class CloudKitPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .CloudKit
+    public let message: String
+    
+    public init(message: String) {
+            self.message = message
+    }
+}
+
+@objc public class HealthPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .HealthKit
+    public let message: String
+    public let healthTypesToShare: Set<HKSampleType>?
+    public let healthTypesToRead: Set<HKObjectType>?
+    
+    public init(message: String, healthTypesToShare: Set<HKSampleType>?,
+        healthTypesToRead: Set<HKObjectType>?) {
+            self.healthTypesToShare = healthTypesToShare
+            self.healthTypesToRead = healthTypesToRead
+            self.message = message
     }
 }

--- a/PermissionScope/PermissionConfigs.swift
+++ b/PermissionScope/PermissionConfigs.swift
@@ -1,0 +1,132 @@
+//
+//  PermissionConfigs.swift
+//  PermissionScope
+//
+//  Created by Nick O'Neill on 8/25/15.
+//  Copyright © 2015 That Thing in Swift. All rights reserved.
+//
+
+import Foundation
+import HealthKit
+import Accounts
+
+@objc public protocol PermissionConfig {
+    var type: PermissionType { get }
+    var message: String { get }
+}
+
+@objc public class NotificationsPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType
+    public let message: String
+    public let notificationCategories: Set<UIUserNotificationCategory>?
+    
+    public init(message: String, notificationCategories: Set<UIUserNotificationCategory>? = .None) {
+        self.notificationCategories = notificationCategories
+        self.type                   = .Notifications
+        self.message                = message
+    }
+}
+
+@objc public class HealthPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .HealthKit
+    public let message: String
+    public let healthTypesToShare: Set<HKSampleType>?
+    public let healthTypesToRead: Set<HKObjectType>?
+    
+    public init(message: String, healthTypesToShare: Set<HKSampleType>?,
+        healthTypesToRead: Set<HKObjectType>?) {
+            self.healthTypesToShare = healthTypesToShare
+            self.healthTypesToRead = healthTypesToRead
+            self.message = message
+    }
+}
+
+@objc public class LocationWhileInUsePermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .LocationInUse
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class LocationAlwaysPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .LocationAlways
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class ContactsPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Contacts
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class EventsPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Events
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class MicrophonePermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Microphone
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class CameraPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Camera
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class PhotosPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Photos
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class RemindersPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Reminders
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class BluetoothPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Bluetooth
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+@objc public class MotionPermissionConfig: NSObject, PermissionConfig {
+    public let type: PermissionType = .Motion
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}

--- a/PermissionScope/PermissionConfigs.swift
+++ b/PermissionScope/PermissionConfigs.swift
@@ -135,11 +135,13 @@ import Accounts
     public let message: String
     public let healthTypesToShare: Set<HKSampleType>?
     public let healthTypesToRead: Set<HKObjectType>?
+    public let strictMode: Bool
     
     public init(message: String, healthTypesToShare: Set<HKSampleType>?,
-        healthTypesToRead: Set<HKObjectType>?) {
+        healthTypesToRead: Set<HKObjectType>?, strictMode: Bool = false) {
             self.healthTypesToShare = healthTypesToShare
             self.healthTypesToRead = healthTypesToRead
             self.message = message
+            self.strictMode = strictMode
     }
 }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -473,8 +473,7 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
         case .Unknown:
             let notificationsPermission = self.configuredPermissions
                 .first { $0 is NotificationsPermissionConfig } as? NotificationsPermissionConfig
-            
-            guard let notificationsPermissionSet = notificationsPermission?.notificationCategories else { return }
+            let notificationsPermissionSet = notificationsPermission?.notificationCategories
 
             NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("showingNotificationPermission"), name: UIApplicationWillResignActiveNotification, object: nil)
             
@@ -484,7 +483,6 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
                 UIUserNotificationSettings(forTypes: [.Alert, .Sound, .Badge],
                 categories: notificationsPermissionSet)
             )
-            
         case .Unauthorized:
             showDeniedAlert(.Notifications)
         case .Disabled:

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -188,18 +188,18 @@ import HealthKit
 
         // offset the header from the content center, compensate for the content's offset
         headerLabel.center = contentView.center
-        headerLabel.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-        headerLabel.frame.offset(dx: 0, dy: -((dialogHeight/2)-50))
+        headerLabel.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+        headerLabel.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-50))
 
         // ... same with the body
         bodyLabel.center = contentView.center
-        bodyLabel.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-        bodyLabel.frame.offset(dx: 0, dy: -((dialogHeight/2)-100))
+        bodyLabel.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+        bodyLabel.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-100))
         
         closeButton.center = contentView.center
-        closeButton.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-        closeButton.frame.offset(dx: 105, dy: -((dialogHeight/2)-20))
-        closeButton.frame.offset(dx: self.closeOffset.width, dy: self.closeOffset.height)
+        closeButton.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+        closeButton.frame.offsetInPlace(dx: 105, dy: -((dialogHeight/2)-20))
+        closeButton.frame.offsetInPlace(dx: self.closeOffset.width, dy: self.closeOffset.height)
         if closeButton.imageView?.image != nil {
             closeButton.setTitle("", forState: UIControlState.Normal)
         }
@@ -209,8 +209,8 @@ import HealthKit
         var index = 0
         for button in permissionButtons {
             button.center = contentView.center
-            button.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-            button.frame.offset(dx: 0, dy: -((dialogHeight/2)-160) + CGFloat(index * baseOffset))
+            button.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+            button.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-160) + CGFloat(index * baseOffset))
             
             let type = configuredPermissions[index].type
             
@@ -229,8 +229,8 @@ import HealthKit
 
             let label = permissionLabels[index]
             label.center = contentView.center
-            label.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-            label.frame.offset(dx: 0, dy: -((dialogHeight/2)-205) + CGFloat(index * baseOffset))
+            label.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+            label.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-205) + CGFloat(index * baseOffset))
 
             index++
         }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -1019,6 +1019,8 @@ public typealias cancelClosureType    = (results: [PermissionResult]) -> Void
                 self.showDisabledAlert(.CloudKit)
             case .CouldNotDetermine:
                 // Ask user to login to iCloud
+                print(error!.localizedDescription)
+                // TODO: What should we return ? Use throws ?
                 break
             }
         }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -919,12 +919,12 @@ public typealias cancelClosureType    = (results: [PermissionResult]) -> Void
         guard HKHealthStore.isHealthDataAvailable() else { return .Disabled }
         
         var statusArray:[HKAuthorizationStatus] = []
-        typesToShare?.forEach({ (elem) -> () in
-            statusArray.append(HKHealthStore().authorizationStatusForType(elem))
-        })
-        typesToRead?.forEach({ (elem) -> () in
-            statusArray.append(HKHealthStore().authorizationStatusForType(elem))
-        })
+        typesToShare?.forEach {
+            statusArray.append(HKHealthStore().authorizationStatusForType($0))
+        }
+        typesToRead?.forEach {
+            statusArray.append(HKHealthStore().authorizationStatusForType($0))
+        }
         
         // TODO: What to do? If there's 1 .Denied or ND then return such result ?
         // Only Auth if they are all Auth ?

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -192,18 +192,18 @@ import CloudKit
 
         // offset the header from the content center, compensate for the content's offset
         headerLabel.center = contentView.center
-        headerLabel.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-        headerLabel.frame.offset(dx: 0, dy: -((dialogHeight/2)-50))
+        headerLabel.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+        headerLabel.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-50))
 
         // ... same with the body
         bodyLabel.center = contentView.center
-        bodyLabel.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-        bodyLabel.frame.offset(dx: 0, dy: -((dialogHeight/2)-100))
+        bodyLabel.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+        bodyLabel.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-100))
         
         closeButton.center = contentView.center
-        closeButton.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-        closeButton.frame.offset(dx: 105, dy: -((dialogHeight/2)-20))
-        closeButton.frame.offset(dx: self.closeOffset.width, dy: self.closeOffset.height)
+        closeButton.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+        closeButton.frame.offsetInPlace(dx: 105, dy: -((dialogHeight/2)-20))
+        closeButton.frame.offsetInPlace(dx: self.closeOffset.width, dy: self.closeOffset.height)
         if closeButton.imageView?.image != nil {
             closeButton.setTitle("", forState: .Normal)
         }
@@ -213,8 +213,8 @@ import CloudKit
         var index = 0
         for button in permissionButtons {
             button.center = contentView.center
-            button.frame.offset(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
-            button.frame.offset(dx: 0, dy: -((dialogHeight/2)-160) + CGFloat(index * baseOffset))
+            button.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
+            button.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-160) + CGFloat(index * baseOffset))
             
             let type = configuredPermissions[index].type
             
@@ -234,8 +234,8 @@ import CloudKit
                     
                     let label = self.permissionLabels[index]
                     label.center = self.contentView.center
-                    label.frame.offset(dx: -self.contentView.frame.origin.x, dy: -self.contentView.frame.origin.y)
-                    label.frame.offset(dx: 0, dy: -((dialogHeight/2)-205) + CGFloat(index * baseOffset))
+                    label.frame.offsetInPlace(dx: -self.contentView.frame.origin.x, dy: -self.contentView.frame.origin.y)
+                    label.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-205) + CGFloat(index * baseOffset))
                     
                     index++
             })
@@ -753,7 +753,7 @@ import CloudKit
                     statusCallback(status: .Unauthorized)
                 case .CouldNotComplete:
                     // Error ocurred.
-                    print(error!.localizedDescription, appendNewline: true)
+                    print(error!.localizedDescription, terminator: "\n")
                     // TODO: What should we return ? Use throws ?
                     statusCallback(status: .Unknown)
                 }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -983,22 +983,23 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
                 }
         }
         
+        let alert = UIAlertController(title: "Permission for \(permission) was denied.",
+            message: "Please enable access to \(permission) in the Settings app",
+            preferredStyle: .Alert)
+        alert.addAction(UIAlertAction(title: "OK",
+            style: .Cancel,
+            handler: nil))
+        alert.addAction(UIAlertAction(title: "Show me",
+            style: .Default,
+            handler: { (action) -> Void in
+                NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("appForegroundedAfterSettings"), name: UIApplicationDidBecomeActiveNotification, object: nil)
+                
+                let settingsUrl = NSURL(string: UIApplicationOpenSettingsURLString)
+                UIApplication.sharedApplication().openURL(settingsUrl!)
+        }))
+        
         dispatch_group_notify(group,
             dispatch_get_main_queue()) { () -> Void in
-                let alert = UIAlertController(title: "Permission for \(permission) was denied.",
-                    message: "Please enable access to \(permission) in the Settings app",
-                    preferredStyle: .Alert)
-                alert.addAction(UIAlertAction(title: "OK",
-                    style: .Cancel,
-                    handler: nil))
-                alert.addAction(UIAlertAction(title: "Show me",
-                    style: .Default,
-                    handler: { (action) -> Void in
-                        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("appForegroundedAfterSettings"), name: UIApplicationDidBecomeActiveNotification, object: nil)
-                        
-                        let settingsUrl = NSURL(string: UIApplicationOpenSettingsURLString)
-                        UIApplication.sharedApplication().openURL(settingsUrl!)
-                }))
                 self.viewControllerForAlerts?.presentViewController(alert,
                     animated: true, completion: nil)
         }
@@ -1017,14 +1018,15 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
                 }
         }
         
+        let alert = UIAlertController(title: "\(permission) is currently disabled.",
+            message: "Please enable access to \(permission) in Settings",
+            preferredStyle: .Alert)
+        alert.addAction(UIAlertAction(title: "OK",
+            style: .Cancel,
+            handler: nil))
+        
         dispatch_group_notify(group,
             dispatch_get_main_queue()) { () -> Void in
-                let alert = UIAlertController(title: "\(permission) is currently disabled.",
-                    message: "Please enable access to \(permission) in Settings",
-                    preferredStyle: .Alert)
-                alert.addAction(UIAlertAction(title: "OK",
-                    style: .Cancel,
-                    handler: nil))
                 self.viewControllerForAlerts?.presentViewController(alert,
                     animated: true, completion: nil)
         }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -33,7 +33,7 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
     let baseView    = UIView()
     let contentView = UIView()
 
-    // various managers
+    // MARK: - Various lazy managers
     lazy var locationManager:CLLocationManager = {
         let lm = CLLocationManager()
         lm.delegate = self
@@ -48,17 +48,20 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
         return CMMotionActivityManager()
     }()
     
+    /// NSUserDefaults standardDefaults lazy var
     lazy var defaults:NSUserDefaults = {
         return .standardUserDefaults()
     }()
     
-    // Default status for CoreMotion
+    /// Default status for CoreMotion
     var motionPermissionStatus: PermissionStatus = .Unknown
 
-    // Internal state and resolution
+    // MARK: - Internal state and resolution
+    
+    /// Permissions configured using addPermission(:)
     var configuredPermissions: [PermissionConfig] = []
-    var permissionButtons: [UIButton] = []
-    var permissionLabels: [UILabel] = []
+    var permissionButtons: [UIButton]             = []
+    var permissionLabels: [UILabel]               = []
 	
 	// Useful for direct use of the request* methods
     public var authChangeClosure: authClosureType? = nil
@@ -96,7 +99,6 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
         var statuses: Dictionary<PermissionType, PermissionStatus> = [:]
         let types: [PermissionType] = permissionTypes ?? PermissionType.allValues
         
-        // FIXME: Return after async calls were executed
         for type in types {
             statusForPermission(type, completion: { (status) -> Void in
                 statuses[type] = status
@@ -787,7 +789,7 @@ public typealias statusRequestClosure = (status: PermissionStatus) -> Void
             self.showDeniedAlert(.HealthKit)
         case .Disabled:
             self.showDisabledAlert(.HealthKit)
-        default:
+        case .Authorized:
             break
         }
     }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -720,8 +720,6 @@ import HealthKit
             statusArray.append(HKHealthStore().authorizationStatusForType(elem))
         })
         
-//        print(statusArray)
-        
         // TODO: What to do? If there's 1 .Denied or ND then return such result ?
         // Only Auth if they are all Auth ?
         let typesAuthorized = statusArray
@@ -749,7 +747,7 @@ import HealthKit
             HKHealthStore().requestAuthorizationToShareTypes(healthPermission.healthTypesToShare,
                 readTypes: healthPermission.healthTypesToRead,
                 completion: { (granted, error) -> Void in
-                    print("requestAuthorizationToShareTypes: ", granted, " - error: ", error)
+                    if let error = error { print("error: ", error) }
                     self.detectAndCallback()
             })
         case .Unauthorized:

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -753,7 +753,7 @@ import CloudKit
                     statusCallback(status: .Unauthorized)
                 case .CouldNotComplete:
                     // Error ocurred.
-                    print(error!.localizedDescription, terminator: "\n")
+                    print(error!.localizedDescription)
                     // TODO: What should we return ? Use throws ?
                     statusCallback(status: .Unknown)
                 }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -14,6 +14,7 @@ import Photos
 import EventKit
 import CoreBluetooth
 import CoreMotion
+import HealthKit
 
 @objc public class PermissionScope: UIViewController, CLLocationManagerDelegate, UIGestureRecognizerDelegate, CBPeripheralManagerDelegate {
 
@@ -713,6 +714,40 @@ import CoreMotion
     
     private var waitingForMotion = false
     
+    // MARK: HealthKit
+    public func statusHealthKit() -> PermissionStatus {
+        guard HKHealthStore.isHealthDataAvailable() else { return .Disabled }
+        
+        let status = HKHealthStore().authorizationStatusForType(HKObjectType.workoutType())
+        switch status {
+        case .SharingAuthorized:
+            return .Authorized
+        case .SharingDenied:
+            return .Unauthorized
+        case .NotDetermined:
+            return .Unknown
+        }
+    }
+    
+    func requestHealthKit() {
+        let aux = self.configuredPermissions.first
+//            .filter { $0.type.isHealthKit }
+//            .first
+        
+//        switch statusHealthKit() {
+//        case .Unknown:
+//            HKHealthStore().requestAuthorizationToShareTypes(<#T##typesToShare: Set<HKSampleType>?##Set<HKSampleType>?#>,
+//                readTypes: <#T##Set<HKObjectType>?#>,
+//                completion: { (granted, error) -> Void in
+//                    self.detectAndCallback()
+//            })
+//        case .Unauthorized:
+//            self.showDeniedAlert(.Reminders)
+//        default:
+//            break
+//        }
+    }
+    
     // MARK: - UI
 
     @objc public func show(authChange: ((finished: Bool, results: [PermissionResult]) -> Void)? = nil, cancelled: ((results: [PermissionResult]) -> Void)? = nil) {
@@ -911,6 +946,8 @@ import CoreMotion
             return statusBluetooth()
         case .Motion:
             return statusMotion()
+        case .HealthKit:
+            return statusHealthKit()
         }
     }
     

--- a/PermissionScope/Structs.swift
+++ b/PermissionScope/Structs.swift
@@ -9,6 +9,7 @@
 import Foundation
 import HealthKit
 
+/// Permissions currently supportes by PermissionScope
 @objc public enum PermissionType: Int, CustomStringConvertible {
     case Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, HealthKit, CloudKit
     
@@ -19,13 +20,6 @@ import HealthKit
         default:
             return "\(self)"
         }
-    }
-    
-    public var isHealthKit: Bool {
-        if case .HealthKit = self {
-            return true
-        }
-        return false
     }
     
     public var description: String {
@@ -49,6 +43,7 @@ import HealthKit
     static let allValues = [Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, HealthKit, CloudKit]
 }
 
+/// Possible statuses for a permission.
 @objc public enum PermissionStatus: Int, CustomStringConvertible {
     case Authorized, Unauthorized, Unknown, Disabled
     
@@ -62,6 +57,7 @@ import HealthKit
     }
 }
 
+/// Result for a permission status request.
 @objc public class PermissionResult: NSObject {
     public let type: PermissionType
     public let status: PermissionStatus

--- a/PermissionScope/Structs.swift
+++ b/PermissionScope/Structs.swift
@@ -7,9 +7,10 @@
 //
 
 import Foundation
+import HealthKit
 
-@objc public enum PermissionType: Int {
-    case Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion
+@objc public enum PermissionType: Int, Hashable {
+    case Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, HealthKit(Set<HKSampleType>?, Set<HKObjectType>?)
     
     public var prettyDescription: String {
         switch self {
@@ -20,8 +21,24 @@ import Foundation
         }
     }
     
+    public var hashValue: Int {
+        switch self {
+        case HealthKit(let typesToShare, let typesToRead):
+            return (typesToShare?.hashValue ?? 1) ^ (typesToRead?.hashValue ?? 1)
+        default:
+            return "\(self)".hashValue
+        }
+    }
+    
+    public var isHealthKit: Bool {
+        if case .HealthKit = self {
+            return true
+        }
+        return false
+    }
+    
     // Watch out for 
-    static let allValues = [Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion]
+    static let allValues = [Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, HealthKit(nil, nil)]
     
 }
 

--- a/PermissionScope/Structs.swift
+++ b/PermissionScope/Structs.swift
@@ -9,8 +9,8 @@
 import Foundation
 import HealthKit
 
-@objc public enum PermissionType: Int, Hashable {
-    case Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, HealthKit(Set<HKSampleType>?, Set<HKObjectType>?)
+@objc public enum PermissionType: Int, CustomStringConvertible {
+    case Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, HealthKit
     
     public var prettyDescription: String {
         switch self {
@@ -18,15 +18,6 @@ import HealthKit
             return "Location"
         default:
             return "\(self)"
-        }
-    }
-    
-    public var hashValue: Int {
-        switch self {
-        case HealthKit(let typesToShare, let typesToRead):
-            return (typesToShare?.hashValue ?? 1) ^ (typesToRead?.hashValue ?? 1)
-        default:
-            return "\(self)".hashValue
         }
     }
     
@@ -50,12 +41,12 @@ import HealthKit
         case .Reminders:        return "Reminders"
         case .Bluetooth:        return "Bluetooth"
         case .Motion:           return "Motion"
-        case .HealthKit(_, _):  return "HealthKit"
+        case .HealthKit:        return "HealthKit"
         }
     }
     
     // Watch out for
-    static let allValues = [Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion]
+    static let allValues:[PermissionType] = [Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, HealthKit]
 }
 
 @objc public enum PermissionStatus: Int, CustomStringConvertible {
@@ -68,23 +59,6 @@ import HealthKit
         case .Unknown:      return "Unknown"
         case .Disabled:     return "Disabled" // System-level
         }
-    }
-}
-
-@objc public class PermissionConfig: NSObject {
-    let type: PermissionType
-    let message: String
-    
-    let notificationCategories: Set<UIUserNotificationCategory>?
-    
-    public init(type: PermissionType, message: String, notificationCategories: Set<UIUserNotificationCategory>? = .None) {
-        if type != .Notifications && notificationCategories != .None {
-            assertionFailure("notificationCategories only apply to the .Notifications permission")
-        }
-        
-        self.type                   = type
-        self.message                = message
-        self.notificationCategories = notificationCategories
     }
 }
 

--- a/PermissionScope/Structs.swift
+++ b/PermissionScope/Structs.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @objc public enum PermissionType: Int, CustomStringConvertible {
-    case Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion
+    case Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, CloudKit
     
     public var prettyDescription: String {
         switch self {
@@ -33,11 +33,12 @@ import Foundation
         case .Reminders: return "Reminders"
         case .Bluetooth: return "Bluetooth"
         case .Motion: return "Motion"
+        case .CloudKit: return "CloudKit"
         }
     }
     
     // Watch out for
-    static let allValues = [Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion]
+    static let allValues = [Contacts, LocationAlways, LocationInUse, Notifications, Microphone, Camera, Photos, Reminders, Events, Bluetooth, Motion, CloudKit]
     
 }
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Enable `HealthKit` under your target's capabilities, **required**.
 
 Enable `CloudKit` under your target's capabilities, **required**.
 
-Also, remember to add an observer and manage [CKAccountChangedNotification](https://developer.apple.com/library/prerelease/ios/documentation/CloudKit/Reference/CKContainer_class/#//apple_ref/c/data/CKAccountChangedNotification).
+Also, remember to add an observer and manage [CKAccountChangedNotification](https://developer.apple.com/library/prerelease/ios/documentation/CloudKit/Reference/CKContainer_class/#//apple_ref/c/data/CKAccountChangedNotification) in your app.
 
 ## projects using PermissionScope
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ PermissionScope gives you space to explain your reasons for requesting their pre
 Best of all, PermissionScope detects when ([some of](https://github.com/nickoneill/PermissionScope/issues/9)) your permissions have been denied by a user and gives them an easy prompt to go into the system settings page to modify these permissions.
 
 ## Table of Contents
-* [Installation](https://github.com/nickoneill/PermissionScope/#-installation)
-* [Dialog Usage](https://github.com/nickoneill/PermissionScope/#-dialog-usage)
-* [Unified Permissions API](https://github.com/nickoneill/PermissionScope/#-unified-permissions-api)
-* [Issues](https://github.com/nickoneill/PermissionScope/#-issues)
-* [Extra Requirements for Permissions](https://github.com/nickoneill/PermissionScope/#-extra-requirements-for-permissions)
-* [Projects using PermissionScope](https://github.com/nickoneill/PermissionScope/#-projects-using-permissionscope)
-* [License](https://github.com/nickoneill/PermissionScope/#-license)
+* [Installation](https://github.com/nickoneill/PermissionScope/#installation)
+* [Dialog Usage](https://github.com/nickoneill/PermissionScope/#dialog-usage)
+* [Unified Permissions API](https://github.com/nickoneill/PermissionScope/#unified-permissions-api)
+* [Issues](https://github.com/nickoneill/PermissionScope/#issues)
+* [Extra Requirements for Permissions](https://github.com/nickoneill/PermissionScope/#extra-requirements-for-permissions)
+* [Projects using PermissionScope](https://github.com/nickoneill/PermissionScope/#projects-using-permissionscope)
+* [License](https://github.com/nickoneill/PermissionScope/#license)
 
 
 ## installation

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ PermissionScope gives you space to explain your reasons for requesting their pre
 
 Best of all, PermissionScope detects when ([some of](https://github.com/nickoneill/PermissionScope/issues/9)) your permissions have been denied by a user and gives them an easy prompt to go into the system settings page to modify these permissions.
 
+## Table of Contents
+* [Installation](https://github.com/nickoneill/PermissionScope/#-installation)
+* [Dialog Usage](https://github.com/nickoneill/PermissionScope/#-dialog-usage)
+* [Unified Permissions API](https://github.com/nickoneill/PermissionScope/#-unified-permissions-api)
+* [Issues](https://github.com/nickoneill/PermissionScope/#-issues)
+* [Extra Requirements for Permissions](https://github.com/nickoneill/PermissionScope/#-extra-requirements-for-permissions)
+* [Projects using PermissionScope](https://github.com/nickoneill/PermissionScope/#-projects-using-permissionscope)
+* [License](https://github.com/nickoneill/PermissionScope/#-license)
+
+
 ## installation
 
 * requires iOS 8+
@@ -75,7 +85,7 @@ A permission can either have `.Required` or .`Optional` demands. Required permis
 
 A permission with the `.Optional` demand will not cause the dialog to show alone. Users who have accepted all the required permissions but not all optional permissions can tap out to continue without allowing the optional permissions.
 
-### customizability
+### ui customization
 
 You can easily change the colors, label and buttons fonts with PermissionScope.
 
@@ -91,7 +101,7 @@ pscope.labelFont = UIFont...
 
 In addition, the default behavior for tapping the background behind the dialog is to cancel the dialog (which calls the cancel closure you can provide on `show`). You can change this behavior with `backgroundTapCancels` during init.
 
-### unified permissions API
+## unified permissions API
 
 PermissionScope also has an abstracted API for getting the state for a given permission and requesting permissions if you need to do so outside of the normal dialog UI. Think of it as a unified iOS permissions API that can provide some features that even Apple does not (such as detecting denied notification permissions).
 
@@ -159,7 +169,7 @@ If you're also using PermissionScope in the traditional manner, don't forget to 
 pscope.viewControllerForAlerts = pscope as UIViewController
 ```
 
-### issues
+## issues
 
 * You get "Library not loaded: @rpath/libswiftCoreAudio.dylib", "image not found" errors when your app runs:
 
@@ -171,25 +181,29 @@ We're using PermissionScope in [treat](https://gettre.at) and fixing issues as t
 ### PermissionScope registers user notification settings, not remote notifications
 Users will get the prompt to enable notifications when using PermissionScope but it's up to you to watch for results in your app delegate's `didRegisterUserNotificationSettings` and then register for remote notifications independently. This won't alert the user again. You're still responsible for handling the shipment of user notification settings off to your push server.
 
-### notes about location
+## extra requirements for permissions
+
+### location 
 **You must set these Info.plist keys for location to work**
 
 Trickiest part of implementing location permissions? You must implement the proper key in your Info.plist file with a short description of how your app uses location info (shown in the system permissions dialog). Without this, trying to get location  permissions will just silently fail. *Software*!
 
 Use `NSLocationAlwaysUsageDescription` or `NSLocationWhenInUseUsageDescription` where appropriate for your app usage. You can specify which of these location permissions you wish to request with `.LocationAlways` or `.LocationInUse` while configuring PermissionScope.
 
-### notes about bluetooth
+### bluetooth
+**You must set these Info.plist keys for location to work**
+
 The *NSBluetoothPeripheralUsageDescription* key in the Info.plist specifying a short description of why your app needs to act as a bluetooth peripheralin the background is **optional**. 
 
 However, enabling `background-modes` in the capabilities section and checking the `acts as a bluetooth LE accessory` checkbox is **required**.
 
-### projects using PermissionScope
+## projects using PermissionScope
 
 Feel free to add your project in a PR if you're using PermissionScope:
 
 <img src="http://raquo.net/images/icon-round-80.png" width="40" height="40" /><br />
 <a href="https://gettre.at">treat</a>
 
-### license, etc
+## license
 
 PermissionScope uses the MIT license. Please file an issue if you have any questions or if you'd like to share how you're using this tool.

--- a/README.md
+++ b/README.md
@@ -191,11 +191,20 @@ Trickiest part of implementing location permissions? You must implement the prop
 Use `NSLocationAlwaysUsageDescription` or `NSLocationWhenInUseUsageDescription` where appropriate for your app usage. You can specify which of these location permissions you wish to request with `.LocationAlways` or `.LocationInUse` while configuring PermissionScope.
 
 ### bluetooth
-**You must set these Info.plist keys for location to work**
 
 The *NSBluetoothPeripheralUsageDescription* key in the Info.plist specifying a short description of why your app needs to act as a bluetooth peripheralin the background is **optional**. 
 
 However, enabling `background-modes` in the capabilities section and checking the `acts as a bluetooth LE accessory` checkbox is **required**.
+
+### healthkit
+
+Enable `HealthKit` under your target's capabilities, **required**.
+
+### cloudkit
+
+Enable `CloudKit` under your target's capabilities, **required**.
+
+Also, remember to add an observer and manage [CKAccountChangedNotification](https://developer.apple.com/library/prerelease/ios/documentation/CloudKit/Reference/CKContainer_class/#//apple_ref/c/data/CKAccountChangedNotification).
 
 ## projects using PermissionScope
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ pscope.viewControllerForAlerts = pscope as UIViewController
 
 ## issues
 
-* You get "Library not loaded: @rpath/libswiftCoreAudio.dylib", "image not found" errors when your app runs:
+* You get `Library not loaded: @rpath/libswiftCoreAudio.dylib`, `image not found` errors when your app runs:
 
 PermissionScope imports CoreAudio to request microphone access but it's not automatically linked in if your app doesn't `import CoreAudio` somewhere. I'm not sure if this is a bug or a a quirk of how CoreAudio is imported. For now, if you `import CoreAudio` in your top level project it should fix the issue.
 


### PR DESCRIPTION
- Support for closures in status/request functions added (Needed for CloudKit async requests).
- Added CloudKit (#58)
- Added HealthKit (#17)

**Do not merge until these are closed**:
- [x] Add notes to readme about CloudKit's notification https://github.com/nickoneill/PermissionScope/issues/58#issuecomment-133592741
- [x] Add notes to readme about HK: Enable HealthKit in the target's _Capabilities_
- [x] Add notes to readme about CK: Enable CloudKit in the target's _Capabilities_
- [ ] https://github.com/nickoneill/PermissionScope/issues/17#issuecomment-134838190

> What to do when the user asks for _x_ types to share and _y_ types to read ? Return .Authorized if all of them were ? What about  SharingDenied and NotDetermined  ? [Link to the code](https://github.com/bre7/PermissionScope/blob/wip/health-cloud-kit/PermissionScope/PermissionScope.swift#L767)
