### PR TITLE
Add the functionality to alter the (un)authorised button color

### DIFF
--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -25,41 +25,19 @@ import CoreMotion
     public var labelFont = UIFont.systemFontOfSize(14)
     public var closeButton = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 32))
     public var closeOffset = CGSize(width: 0, height: 0)
-    public var useInverseColorForAuthButtons = true
     
-    ///  If you want to set costum colors to the authorized and unauthorized buttons, you first have to set useInverseColorForAuthButtons to false
-    public var authorizedButtonColor : UIColor{
+    private var authorizedButtonColor : UIColor{
         get{
             return tintColor
         }
         set(newColor){
-            if useInverseColorForAuthButtons{
-                tintColor = newColor
-                unauthorized = newColor.inverseColor
-            }
-            else{
+            // think about renaming tintColor. isn't really clear what it does unless you read into the code
             tintColor = newColor
-            }
         }
     }
     
-    // If you want to set costum colors to the authorized and unauthorized buttons, you first have to set useInverseColorForAuthButtons to false
-    public var unauthorizedButtonColor:UIColor{
-        get {
-            return unauthorized
-        }
-        set(newColor){
-            if useInverseColorForAuthButtons{
-                unauthorized = newColor
-                tintColor = newColor.inverseColor
-            }
-            else{
-                unauthorized = newColor
-            }
-        }
-    }
+    private var unauthorizedButtonColor = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1).inverseColor
     
-    private var unauthorized : UIColor = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1).inverseColor
 
     // MARK: View hierarchy for custom alert
     let baseView = UIView()
@@ -910,6 +888,31 @@ import CoreMotion
             handler: nil))
         viewControllerForAlerts?.presentViewController(alert,
             animated: true, completion: nil)
+    }
+    
+    /** sets the color of authorized permission buttons.        
+        useInverse indicates, if unauthorized permission colors should be displayed in the inverse color of the newColor
+    */
+    public func setAuthorizedButtonColor(newColor:UIColor, useInverse:Bool){
+        
+        authorizedButtonColor = newColor
+        
+        if useInverse{
+            unauthorizedButtonColor = newColor.inverseColor
+        }
+    }
+    
+    
+    /** sets the color of unauthorized permission buttons.
+        useInverse indicates, if authorized permission colors should be displayed in the inverse color of the newColor
+    */
+    public func setUnauthorizedButtonColor(newColor:UIColor, useInverse:Bool){
+        
+        unauthorizedButtonColor = newColor
+        
+        if useInverse{
+            authorizedButtonColor = newColor.inverseColor
+        }
     }
 
     // MARK: Helpers

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -289,7 +289,7 @@ import CoreMotion
     func setButtonUnauthorizedStyle(button: UIButton) {
         button.layer.borderWidth = 0
         
-        button.backgroundColor = (unauthorizedButtonColor != nil ? unauthorizedButtonColor : authorizedButtonColor.inverseColor)
+        button.backgroundColor = unauthorizedButtonColor ?? authorizedButtonColor.inverseColor
         
         button.setTitleColor(UIColor.whiteColor(), forState: UIControlState.Normal)
     }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -26,17 +26,9 @@ import CoreMotion
     public var closeButton = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 32))
     public var closeOffset = CGSize(width: 0, height: 0)
     
-    private var authorizedButtonColor : UIColor{
-        get{
-            return tintColor
-        }
-        set(newColor){
-            // think about renaming tintColor. isn't really clear what it does unless you read into the code
-            tintColor = newColor
-        }
-    }
+    public var authorizedButtonColor = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1)
     
-    private var unauthorizedButtonColor = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1).inverseColor
+    public var unauthorizedButtonColor:UIColor?
     
 
     // MARK: View hierarchy for custom alert
@@ -296,7 +288,13 @@ import CoreMotion
     
     func setButtonUnauthorizedStyle(button: UIButton) {
         button.layer.borderWidth = 0
-        button.backgroundColor = unauthorizedButtonColor
+        
+        if let unauthColor = unauthorizedButtonColor{
+            button.backgroundColor = unauthColor
+        }else{
+            button.backgroundColor = authorizedButtonColor.inverseColor
+        }
+        
         button.setTitleColor(UIColor.whiteColor(), forState: UIControlState.Normal)
     }
 
@@ -888,31 +886,6 @@ import CoreMotion
             handler: nil))
         viewControllerForAlerts?.presentViewController(alert,
             animated: true, completion: nil)
-    }
-    
-    /** sets the color of authorized permission buttons.        
-        useInverse indicates, if unauthorized permission colors should be displayed in the inverse color of the newColor
-    */
-    public func setAuthorizedButtonColor(newColor:UIColor, useInverse:Bool){
-        
-        authorizedButtonColor = newColor
-        
-        if useInverse{
-            unauthorizedButtonColor = newColor.inverseColor
-        }
-    }
-    
-    
-    /** sets the color of unauthorized permission buttons.
-        useInverse indicates, if authorized permission colors should be displayed in the inverse color of the newColor
-    */
-    public func setUnauthorizedButtonColor(newColor:UIColor, useInverse:Bool){
-        
-        unauthorizedButtonColor = newColor
-        
-        if useInverse{
-            authorizedButtonColor = newColor.inverseColor
-        }
     }
 
     // MARK: Helpers

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -25,9 +25,7 @@ import CoreMotion
     public var labelFont = UIFont.systemFontOfSize(14)
     public var closeButton = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 32))
     public var closeOffset = CGSize(width: 0, height: 0)
-    
     public var authorizedButtonColor = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1)
-    
     public var unauthorizedButtonColor:UIColor?
     
 
@@ -288,9 +286,7 @@ import CoreMotion
     
     func setButtonUnauthorizedStyle(button: UIButton) {
         button.layer.borderWidth = 0
-        
         button.backgroundColor = unauthorizedButtonColor ?? authorizedButtonColor.inverseColor
-        
         button.setTitleColor(UIColor.whiteColor(), forState: UIControlState.Normal)
     }
 

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -25,6 +25,26 @@ import CoreMotion
     public var labelFont = UIFont.systemFontOfSize(14)
     public var closeButton = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 32))
     public var closeOffset = CGSize(width: 0, height: 0)
+    
+    public var authorizedButtonColor : UIColor{
+        get{
+            return tintColor
+        }
+        set(newColor){
+            tintColor = newColor
+        }
+    }
+    
+    public var unauthorizedButtonColor:UIColor{
+        get {
+            return unauthorized
+        }
+        set(newColor){
+            unauthorized = newColor
+        }
+    }
+    
+    private var unauthorized : UIColor = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1).inverseColor
 
     // MARK: View hierarchy for custom alert
     let baseView = UIView()
@@ -277,13 +297,13 @@ import CoreMotion
 
     func setButtonAuthorizedStyle(button: UIButton) {
         button.layer.borderWidth = 0
-        button.backgroundColor = tintColor
+        button.backgroundColor = authorizedButtonColor
         button.setTitleColor(UIColor.whiteColor(), forState: UIControlState.Normal)
     }
     
     func setButtonUnauthorizedStyle(button: UIButton) {
         button.layer.borderWidth = 0
-        button.backgroundColor = tintColor.inverseColor
+        button.backgroundColor = unauthorizedButtonColor
         button.setTitleColor(UIColor.whiteColor(), forState: UIControlState.Normal)
     }
 

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -25,22 +25,37 @@ import CoreMotion
     public var labelFont = UIFont.systemFontOfSize(14)
     public var closeButton = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 32))
     public var closeOffset = CGSize(width: 0, height: 0)
+    public var useInverseColorForAuthButtons = true
     
+    ///  If you want to set costum colors to the authorized and unauthorized buttons, you first have to set useInverseColorForAuthButtons to false
     public var authorizedButtonColor : UIColor{
         get{
             return tintColor
         }
         set(newColor){
+            if useInverseColorForAuthButtons{
+                tintColor = newColor
+                unauthorized = newColor.inverseColor
+            }
+            else{
             tintColor = newColor
+            }
         }
     }
     
+    // If you want to set costum colors to the authorized and unauthorized buttons, you first have to set useInverseColorForAuthButtons to false
     public var unauthorizedButtonColor:UIColor{
         get {
             return unauthorized
         }
         set(newColor){
-            unauthorized = newColor
+            if useInverseColorForAuthButtons{
+                unauthorized = newColor
+                tintColor = newColor.inverseColor
+            }
+            else{
+                unauthorized = newColor
+            }
         }
     }
     

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -289,11 +289,7 @@ import CoreMotion
     func setButtonUnauthorizedStyle(button: UIButton) {
         button.layer.borderWidth = 0
         
-        if let unauthColor = unauthorizedButtonColor{
-            button.backgroundColor = unauthColor
-        }else{
-            button.backgroundColor = authorizedButtonColor.inverseColor
-        }
+        button.backgroundColor = (unauthorizedButtonColor != nil ? unauthorizedButtonColor : authorizedButtonColor.inverseColor)
         
         button.setTitleColor(UIColor.whiteColor(), forState: UIControlState.Normal)
     }

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -27,7 +27,6 @@ import CoreMotion
     public var closeOffset = CGSize(width: 0, height: 0)
     public var authorizedButtonColor = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1)
     public var unauthorizedButtonColor:UIColor?
-    
 
     // MARK: View hierarchy for custom alert
     let baseView = UIView()


### PR DESCRIPTION
Instead of displaying unauthorized permission buttons in the inverse color of authorized permission buttons, add 2 setters that allow you to set alter these. Old behaviour to use inverse color is still possible by setting the useInverse bool to true when calling those 2 new functions.  

Also changes the color of the close button to give it a more standardised feel. 
