### PR TITLE
Closes #113

### DIFF
--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -1165,6 +1165,14 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
         alert.addAction(UIAlertAction(title: "OK".localized,
             style: .Cancel,
             handler: nil))
+        alert.addAction(UIAlertAction(title: "Show me".localized,
+            style: .Default,
+            handler: { action in
+                NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("appForegroundedAfterSettings"), name: UIApplicationDidBecomeActiveNotification, object: nil)
+                
+                let settingsUrl = NSURL(string: UIApplicationOpenSettingsURLString)
+                UIApplication.sharedApplication().openURL(settingsUrl!)
+        }))
         
         dispatch_async(dispatch_get_main_queue()) {
             self.viewControllerForAlerts?.presentViewController(alert,


### PR DESCRIPTION
Added "Show me" button in disabled alert.

It's easier for the user to use the button than to go to Home...Settings...

Refactor showDenied/Disabled alerts into a single method ? The only difference is the alert text.
