### PR TITLE
Fix infinite loop when waiting for motion status

### DIFF
--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -956,9 +956,9 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
                 
                 self.motionManager.stopActivityUpdates()
                 if tmpMotionPermissionStatus != self.motionPermissionStatus {
-                    self.waitingForMotion = false
                     self.detectAndCallback()
                 }
+                self.waitingForMotion = false
         }
         
         askedMotion = true


### PR DESCRIPTION
This PR fixes a very important issue. I had an infinite loop when I was waiting for motion status. I noticed this accidentally in my app's last version. This used to work and I am not sure what broke it (iOS 9 or some other change in the library) but it should work fine after merging this.
