### PR TITLE
Allow more characters and remove the need for hard-coded line breaks in labels

### DIFF
--- a/PermissionScope-example/ViewController.swift
+++ b/PermissionScope-example/ViewController.swift
@@ -19,14 +19,14 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view, typically from a nib.
         
         singlePscope.addPermission(NotificationsPermission(notificationCategories: nil),
-            message: "We use this to send you\r\nspam and love notes")
+            message: "We use this to send you spam and love notes")
 
         multiPscope.addPermission(ContactsPermission(),
-            message: "We use this to steal\r\nyour friends")
+            message: "We use this to steal your friends")
         multiPscope.addPermission(NotificationsPermission(notificationCategories: nil),
-            message: "We use this to send you\r\nspam and love notes")
+            message: "We use this to send you spam and love notes")
         multiPscope.addPermission(LocationWhileInUsePermission(),
-            message: "We use this to track\r\nwhere you live")
+            message: "We use this to track where you live")
 
         // Other example permissions
 //        multiPscope.addPermission(MicrophonePermission(),message: "We can hear you")

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -186,8 +186,8 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
         bodyLabel.font = UIFont.boldSystemFontOfSize(16)
         bodyLabel.textColor = UIColor.blackColor()
         bodyLabel.textAlignment = NSTextAlignment.Center
-        bodyLabel.text = "We need a couple things\r\nbefore you get started.".localized
-        bodyLabel.numberOfLines = 2
+        bodyLabel.text = "We need a couple things, before you get started.".localized
+        bodyLabel.numberOfLines = 0
 
         contentView.addSubview(bodyLabel)
         
@@ -245,6 +245,8 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
         bodyLabel.center = contentView.center
         bodyLabel.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
         bodyLabel.frame.offsetInPlace(dx: 0, dy: -((dialogHeight/2)-100))
+		bodyLabel.adjustsFontSizeToFitWidth = true
+		bodyLabel.minimumScaleFactor = 0.75
         
         closeButton.center = contentView.center
         closeButton.frame.offsetInPlace(dx: -contentView.frame.origin.x, dy: -contentView.frame.origin.y)
@@ -372,7 +374,9 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
     func permissionStyledLabel(type: PermissionType) -> UILabel {
         let label  = UILabel(frame: CGRect(x: 0, y: 0, width: 260, height: 50))
         label.font = labelFont
-        label.numberOfLines = 2
+        label.numberOfLines = 0
+		label.adjustsFontSizeToFitWidth = true
+		label.minimumScaleFactor = 0.75
         label.textAlignment = .Center
         label.text = permissionMessages[type]
         label.textColor = permissionLabelColor

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -27,7 +27,7 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
     
     /// Header UILabel with the message "Hey, listen!" by default.
     public var headerLabel                 = UILabel(frame: CGRect(x: 0, y: 0, width: 200, height: 50))
-    /// Header UILabel with the message "We need a couple things\r\nbefore you get started." by default.
+    /// Header UILabel with the message "We need a couple things before you get started." by default.
     public var bodyLabel                   = UILabel(frame: CGRect(x: 0, y: 0, width: 240, height: 70))
     /// Color for the close button's text color.
     public var closeButtonTextColor        = UIColor(red: 0, green: 0.47, blue: 1, alpha: 1)

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ class ViewController: UIViewController {
         
         // Set up permissions
         pscope.addPermission(ContactsPermission(),
-            message: "We use this to steal\r\nyour friends")
+            message: "We use this to steal your friends")
         pscope.addPermission(NotificationsPermission(notificationCategories: nil),
-            message: "We use this to send you\r\nspam and love notes")
+            message: "We use this to send you spam and love notes")
         pscope.addPermission(LocationWhileInUsePermission(),
-            message: "We use this to track\r\nwhere you live")
+            message: "We use this to track where you live")
 	
 	// Show dialog with callbacks
         pscope.show({ finished, results in
@@ -93,7 +93,7 @@ You can easily change the colors, label and buttons fonts with PermissionScope b
 Field | Type | Comment
 ----- | ---- | -------
 headerLabel | UILabel | Header UILabel with the message "Hey, listen!" by default.
-bodyLabel | UILabel | Header UILabel with the message "We need a couple things\r\nbefore you get started." by default.
+bodyLabel | UILabel | Header UILabel with the message "We need a couple things before you get started." by default.
 closeButtonTextColor | UIColor | Color for the close button's text color.
 permissionButtonTextColor  | UIColor | Color for the permission buttons' text color.
 permissionButtonBorderColor | UIColor | Color for the permission buttons' border color.

--- a/files/English.strings
+++ b/files/English.strings
@@ -56,7 +56,7 @@
 //
 "Close" = "";
 "Hey, listen!" = "";
-"We need a couple things\r\nbefore you get started." = "";
+"We need a couple things before you get started." = "";
 "Permission for Contacts was denied." = "";
 "Permission for Events was denied." = "";
 "Permission for Location was denied." = "";

--- a/files/German.strings
+++ b/files/German.strings
@@ -56,7 +56,7 @@
 //
 "Close" = "Aus";
 "Hey, listen!" = "Hey, du!";
-"We need a couple things\r\nbefore you get started." = "Wir brauchen noch etwas,\r\n bevor du starten kannst!";
+"We need a couple things before you get started." = "Wir brauchen noch etwas, bevor du starten kannst!";
 "Permission for Contacts was denied." = "Genehmigung für Kontakte wurde abgelehnt.";
 "Permission for Events was denied." = "Erlaubnis für Kalender wurde abgelehnt.";
 "Permission for Location was denied." = "Genehmigung für Standort verweigert wurde.";

--- a/objc-example/ViewController.m
+++ b/objc-example/ViewController.m
@@ -22,13 +22,13 @@
     self.singlePscope = [[PermissionScope alloc]init];
     self.multiPscope = [[PermissionScope alloc]init];
     
-    [self.singlePscope addPermission:[[NotificationsPermission alloc]initWithNotificationCategories:nil] message:@"We use this to send you\r\nspam and love notes"];
+    [self.singlePscope addPermission:[[NotificationsPermission alloc]initWithNotificationCategories:nil] message:@"We use this to send you spam and love notes"];
     
-    [self.multiPscope addPermission:[[ContactsPermission alloc]init] message:@"We use this to steal\r\nyour friends"];
-    [self.multiPscope addPermission:[[NotificationsPermission alloc]initWithNotificationCategories:nil] message:@"We use this to send you\r\nspam and love notes"];
-    [self.multiPscope addPermission:[[LocationWhileInUsePermission alloc]init] message:@"We use this to track\r\nwhere you live"];
+    [self.multiPscope addPermission:[[ContactsPermission alloc]init] message:@"We use this to steal your friends"];
+    [self.multiPscope addPermission:[[NotificationsPermission alloc]initWithNotificationCategories:nil] message:@"We use this to send you spam and love notes"];
+    [self.multiPscope addPermission:[[LocationWhileInUsePermission alloc]init] message:@"We use this to track where you live"];
 //    [self.multiPscope addPermission:[[BluetoothPermission alloc]init] message:@"We use this to drain your battery"];
-//    [self.multiPscope addPermission:[[MotionPermission alloc]init] message:@"We use this to detect if you are\r\nThe Flash"];
+//    [self.multiPscope addPermission:[[MotionPermission alloc]init] message:@"We use this to detect if you are The Flash"];
 }
 
 - (IBAction)single {


### PR DESCRIPTION
I localised some strings to German in another PR (#162) and got the (valid) response that the increasing character count would not lay out well.
Considering the possibility of other languages having a similar affection for long words, I think it's not a bad idea to make the labels more flexible.
I put the proposed minimumScaleFactor to 0.75, which in my opinion still qualifies as legible. In the example of the "bodyLabel" it allows for ~100 additional characters.
This also removes the need to add line breaks into the middle of the strings.
