### PR TITLE
Defines a callback for the notifications permission

### DIFF
--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -102,8 +102,8 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
 	/// View controller to be used when presenting alerts. Defaults to self. You'll want to set this if you are calling the `request*` methods directly.
 	public var viewControllerForAlerts : UIViewController?
 
-    
-    public var notificationRequestCallback:((Void) -> Void)?
+    // If defined, this callback will be called so that the application can handle the request for notifications itself, if not set, Permissionscope will call UIApplication.shared.registerUserNotificationSettings
+    public var notificationRequestCallback:((NotificationsPermission?) -> Void)?
     /**
     Checks whether all the configured permission are authorized or not.
     
@@ -643,7 +643,7 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
             notificationTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(finishedShowingNotificationPermission), userInfo: nil, repeats: false)
             
             if let callback = notificationRequestCallback {
-                callback()
+                callback(notificationsPermission)
             } else {
                 UIApplication.shared.registerUserNotificationSettings(
                     UIUserNotificationSettings(types: [.alert, .sound, .badge],

--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -102,6 +102,8 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
 	/// View controller to be used when presenting alerts. Defaults to self. You'll want to set this if you are calling the `request*` methods directly.
 	public var viewControllerForAlerts : UIViewController?
 
+    
+    public var notificationRequestCallback:((Void) -> Void)?
     /**
     Checks whether all the configured permission are authorized or not.
     
@@ -640,10 +642,14 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
             
             notificationTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(finishedShowingNotificationPermission), userInfo: nil, repeats: false)
             
-            UIApplication.shared.registerUserNotificationSettings(
-                UIUserNotificationSettings(types: [.alert, .sound, .badge],
-                categories: notificationsPermissionSet)
-            )
+            if let callback = notificationRequestCallback {
+                callback()
+            } else {
+                UIApplication.shared.registerUserNotificationSettings(
+                    UIUserNotificationSettings(types: [.alert, .sound, .badge],
+                    categories: notificationsPermissionSet)
+                )
+            }
         case .unauthorized:
             showDeniedAlert(.notifications)
         case .disabled:


### PR DESCRIPTION
When using frameworks like PushWoosh or OneSignal, the app has to call methods on these frameworks to request the permission for notifications from iOS. Since PermissionScope calls UIApplication.shared.registerUserNotificationSettings itself, it is not possible to use PermissionScope and, e.g., OneSignal together in an integrated way.
I have added a notificationRequestCallback which, if set, will be called instead of UIApplication.shared.registerUserNotificationSettings in requestNotifications