### PR TITLE
Fix permissions

### DIFF
--- a/PermissionScope.podspec
+++ b/PermissionScope.podspec
@@ -13,4 +13,91 @@ Pod::Spec.new do |s|
   s.source_files = 'PermissionScope/*.swift'
 
   s.requires_arc = true
+
+  s.default_subspec = 'Core'
+
+  s.subspec 'Core' do |core|
+    core.source_files         = 'PermissionScope/*.{swift,h}'
+  end
+
+  s.subspec 'Motion' do |motion|
+    motion.dependency 'PermissionScope/Core'
+    motion.weak_framework       = 'CoreMotion'
+    feature_flags               = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestMotionEnabled' }
+    motion.pod_target_xcconfig  = feature_flags
+    motion.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Bluetooth' do |bluetooth|
+    bluetooth.dependency 'PermissionScope/Core'
+    bluetooth.weak_framework       = 'CoreBluetooth'
+    feature_flags               = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestBluetoothEnabled' }
+    bluetooth.pod_target_xcconfig  = feature_flags
+    bluetooth.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Location' do |location|
+    location.dependency 'PermissionScope/Core'
+    location.weak_framework       = 'CoreLocation'
+    feature_flags                 = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestLocationEnabled' }
+    location.pod_target_xcconfig  = feature_flags
+    location.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Microphone' do |mic|
+    mic.dependency 'PermissionScope/Core'
+    mic.weak_framework       = 'AVFoundation'
+    feature_flags            = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestMicrophoneEnabled' }
+    mic.pod_target_xcconfig  = feature_flags
+    mic.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'PhotoLibrary' do |photo|
+    photo.dependency 'PermissionScope/Core'
+    photo.weak_framework       = 'Photos', 'AssetsLibrary'
+    feature_flags              = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestPhotoLibraryEnabled' }
+    photo.pod_target_xcconfig  = feature_flags
+    photo.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Camera' do |cam|
+    cam.dependency 'PermissionScope/Core'
+    cam.weak_framework       = 'AVFoundation'
+    feature_flags            = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestCameraEnabled' }
+    cam.pod_target_xcconfig  = feature_flags
+    cam.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Notifications' do |note|
+    note.dependency 'PermissionScope/Core'
+    note.weak_framework       = 'UIKit', 'UserNotifications'
+    feature_flags             = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestNotificationsEnabled' }
+    note.pod_target_xcconfig  = feature_flags
+    note.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Contacts' do |contacts|
+    contacts.dependency 'PermissionScope/Core'
+    contacts.weak_framework       = 'Contacts', 'AddressBook'
+    feature_flags                 = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestContactsEnabled' }
+    contacts.pod_target_xcconfig  = feature_flags
+    contacts.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Events' do |cal|
+    cal.dependency 'PermissionScope/Core'
+    cal.weak_framework       = 'EventKit'
+    feature_flags            = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestEventsEnabled' }
+    cal.pod_target_xcconfig  = feature_flags
+    cal.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Reminders' do |rem|
+    rem.dependency 'PermissionScope/Core'
+    rem.weak_framework       = 'EventKit'
+    feature_flags            = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'PermissionScopeRequestRemindersEnabled' }
+    rem.pod_target_xcconfig  = feature_flags
+    rem.user_target_xcconfig = feature_flags
+  end
+
 end

--- a/PermissionScope.xcodeproj/project.pbxproj
+++ b/PermissionScope.xcodeproj/project.pbxproj
@@ -592,9 +592,11 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thatthinginswift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = PermissionScope;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "PermissionScopeRequestMotionEnabled PermissionScopeRequestBluetoothEnabled PermissionScopeRequestLocationEnabled PermissionScopeRequestMicrophoneEnabled PermissionScopeRequestPhotoLibraryEnabled PermissionScopeRequestCameraEnabled PermissionScopeRequestNotificationsEnabled PermissionScopeRequestContactsEnabled PermissionScopeRequestEventsEnabled PermissionScopeRequestRemindersEnabled";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
@@ -613,9 +615,11 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thatthinginswift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = PermissionScope;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "PermissionScopeRequestMotionEnabled PermissionScopeRequestBluetoothEnabled PermissionScopeRequestLocationEnabled PermissionScopeRequestMicrophoneEnabled PermissionScopeRequestPhotoLibraryEnabled PermissionScopeRequestCameraEnabled PermissionScopeRequestNotificationsEnabled PermissionScopeRequestContactsEnabled PermissionScopeRequestEventsEnabled PermissionScopeRequestRemindersEnabled";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/PermissionScope/Permissions.swift
+++ b/PermissionScope/Permissions.swift
@@ -7,15 +7,6 @@
 //
 
 import Foundation
-import CoreLocation
-import AddressBook
-import AVFoundation
-import Photos
-import EventKit
-import CoreBluetooth
-import CoreMotion
-import CloudKit
-import Accounts
 
 /**
 *  Protocol for permission configurations.
@@ -25,6 +16,7 @@ import Accounts
     var type: PermissionType { get }
 }
 
+#if PermissionScopeRequestNotificationsEnabled
 @objc public class NotificationsPermission: NSObject, Permission {
     public let type: PermissionType = .notifications
     public let notificationCategories: Set<UIUserNotificationCategory>?
@@ -33,46 +25,67 @@ import Accounts
         self.notificationCategories = notificationCategories
     }
 }
+#endif
 
+#if PermissionScopeRequestLocationEnabled
 @objc public class LocationWhileInUsePermission: NSObject, Permission {
     public let type: PermissionType = .locationInUse
 }
+#endif
 
+#if PermissionScopeRequestLocationEnabled
 @objc public class LocationAlwaysPermission: NSObject, Permission {
     public let type: PermissionType = .locationAlways
 }
+#endif
 
+#if PermissionScopeRequestContactsEnabled
 @objc public class ContactsPermission: NSObject, Permission {
     public let type: PermissionType = .contacts
 }
+#endif
 
 public typealias requestPermissionUnknownResult = () -> Void
 public typealias requestPermissionShowAlert     = (PermissionType) -> Void
 
+#if PermissionScopeRequestEventsEnabled
 @objc public class EventsPermission: NSObject, Permission {
     public let type: PermissionType = .events
 }
+#endif
 
+#if PermissionScopeRequestMicrophoneEnabled
 @objc public class MicrophonePermission: NSObject, Permission {
     public let type: PermissionType = .microphone
 }
+#endif
 
+#if PermissionScopeRequestCameraEnabled
 @objc public class CameraPermission: NSObject, Permission {
     public let type: PermissionType = .camera
 }
+#endif
 
+#if PermissionScopeRequestPhotoLibraryEnabled
 @objc public class PhotosPermission: NSObject, Permission {
     public let type: PermissionType = .photos
 }
+#endif
 
+#if PermissionScopeRequestRemindersEnabled
 @objc public class RemindersPermission: NSObject, Permission {
     public let type: PermissionType = .reminders
 }
+#endif
 
+#if PermissionScopeRequestBluetoothEnabled
 @objc public class BluetoothPermission: NSObject, Permission {
     public let type: PermissionType = .bluetooth
 }
+#endif
 
+#if PermissionScopeRequestMotionEnabled
 @objc public class MotionPermission: NSObject, Permission {
     public let type: PermissionType = .motion
 }
+#endif

--- a/PermissionScope/Structs.swift
+++ b/PermissionScope/Structs.swift
@@ -10,9 +10,40 @@ import Foundation
 
 /// Permissions currently supportes by PermissionScope
 @objc public enum PermissionType: Int, CustomStringConvertible {
-    case contacts, locationAlways, locationInUse, notifications, microphone, camera, photos, reminders, events, bluetooth, motion
+    #if PermissionScopeRequestContactsEnabled
+    case contacts
+    #endif
+    #if PermissionScopeRequestLocationEnabled
+    case locationAlways
+    case locationInUse
+    #endif
+    #if PermissionScopeRequestNotificationsEnabled
+    case notifications
+    #endif
+    #if PermissionScopeRequestMicrophoneEnabled
+    case microphone
+    #endif
+    #if PermissionScopeRequestCameraEnabled
+    case camera
+    #endif
+    #if PermissionScopeRequestPhotoLibraryEnabled
+    case photos
+    #endif
+    #if PermissionScopeRequestRemindersEnabled
+    case reminders
+    #endif
+    #if PermissionScopeRequestEventsEnabled
+    case events
+    #endif
+    #if PermissionScopeRequestBluetoothEnabled
+    case bluetooth
+    #endif
+    #if PermissionScopeRequestMotionEnabled
+    case motion
+    #endif
     
     public var prettyDescription: String {
+        // TODO:  This will not compile due to same problem described below.
         switch self {
         case .locationAlways, .locationInUse:
             return "Location"
@@ -22,6 +53,8 @@ import Foundation
     }
     
     public var description: String {
+        /* TODO: This will not compile when used in a project (unless project is asking ALL permissions) because any permission that is not used will have it's enum undefined due to the #ifendif statements around the enum definition above.
+        */
         switch self {
         case .contacts:         return "Contacts"
         case .events:           return "Events"
@@ -37,7 +70,14 @@ import Foundation
         }
     }
     
-    static let allValues = [contacts, locationAlways, locationInUse, notifications, microphone, camera, photos, reminders, events, bluetooth, motion]
+    static var allValues: [PermissionType] {
+        var values = [PermissionType]()
+        for permission in iterateEnum(PermissionType.self) {
+            guard let permissionType = PermissionType(rawValue: permission.rawValue) else { continue }
+            values.append(permissionType)
+        }
+        return values
+    }
 }
 
 /// Possible statuses for a permission.
@@ -66,5 +106,18 @@ import Foundation
     
     override public var description: String {
         return "\(type) \(status)"
+    }
+}
+
+/* Used to iterate through available PermissionType based on permissions in use.  Taken from http://stackoverflow.com/a/28341290/3880396 */
+func iterateEnum<T: Hashable>(_: T.Type) -> AnyIterator<T> {
+    var i = 0
+    return AnyIterator {
+        let next = withUnsafePointer(to: &i) {
+            $0.withMemoryRebound(to: T.self, capacity: 1) { $0.pointee }
+        }
+        if next.hashValue != i { return nil }
+        i += 1
+        return next
     }
 }


### PR DESCRIPTION
This is an attempt to fix issue: https://github.com/nickoneill/PermissionScope/issues/194
It is modeled after this solution used by a similar framework: https://github.com/iosphere/ISHPermissionKit/pull/80/files

In short, the problem is that the framework imports all libraries necessary for all permissions it supports (camera, location, bluetooth, etc), and any app using this library will get automatically rejected if they do not provide ALL plist descriptions - even for the permissions they are not requesting within their app.  

The solution is to hack around with subspecs to define flags that will signal the pod which libraries to import.

The TODO found in this PR illustrates a potential problem with this solution and also the reason why a project using this pod won't build.  Swift does not allow you to put #if #endif around switch cases.  This is a documented bug: https://bugs.swift.org/browse/SR-2

A workaround for this, proposed by Ying is:
```
struct ThingDetail {
    var description = ""
    var permissions: String?
}

var thingDetailOne = ThingDetail(description: "one", permissions: "")
var thingDetailTwo = ThingDetail(description: "two", permissions: "")

enum Thing {
    case one
    #if ENABLE_TWO
    case two
    #endif

    var thingDetail: ThingDetail {
        if self == .one {
            return thingDetailOne
        }
        #if ENABLE_TWO
        if self == .two {
            return thingDetailTwo
        }
        #endif
        return ThingDetail()
    }
}
```

Another solution is to break each permission into it's own framework.  This morning the main repo owner replied to me and said that this would be the right way to go.

Ying supports going the "ThingDetail" struct route.  But after hearing from the repo owner, I think trying to break this into separate frameworks should be the route - as this would be the one he would like to merge in the end.  

