### PR TITLE
Dismissed callback

### DIFF
--- a/PermissionScope.podspec
+++ b/PermissionScope.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'PermissionScope'
-  s.version = '1.1.1'
+  s.version = '1.1.2'
   s.license = 'MIT'
   s.summary = 'A Periscope-inspired way to ask for iOS permissions'
   s.homepage = 'https://github.com/nickoneill/PermissionScope'

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ class ViewController: UIViewController {
             print("got results \(results)")
         }, cancelled: { (results) -> Void in
             print("thing was cancelled")
+        }, dismissed: { canceled in
+            print("the controller was dismissed")
         })   
     }
 }
@@ -157,17 +159,20 @@ You will probably also want to set the `onAuthChange`, `onCancel`, and `onDisabl
 
 ```swift
 pscope.onAuthChange = { (finished, results) in
-	println("Request was finished with results \(results)")
+	print("Request was finished with results \(results)")
 	if results[0].status == .Authorized {
-		println("They've authorized the use of notifications")
+		print("They've authorized the use of notifications")
 		UIApplication.sharedApplication().registerForRemoteNotifications()
 	}
 }
 pscope.onCancel = { results in
-	println("Request was cancelled with results \(results)")
+	print("Request was cancelled with results \(results)")
 }
 pscope.onDisabledOrDenied = { results in
-	println("Request was denied or disabled with results \(results)")
+	print("Request was denied or disabled with results \(results)")
+}
+pscope.onDismissed = { canceled in
+    print("The controller was dismissed by cancel action = \(canceled)")
 }
 ```
 


### PR DESCRIPTION
It'd be fancy if one could track the dismissal of the pscope controller. So I propose just that — instead of doing stuff on `authChange` when `finished` you can set up next transition on the optional `dismissed` callback.
That's my first contribution to a pod, so I don't know whether I should change the version number or not. Please, fix this if needed.