### PR TITLE
Always Embed Swift Standard Libraries = YES

### DIFF
--- a/PermissionScope.xcodeproj/project.pbxproj
+++ b/PermissionScope.xcodeproj/project.pbxproj
@@ -582,6 +582,7 @@
 		D092BA4A1AD1E5A300BFC163 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -603,6 +604,7 @@
 		D092BA4B1AD1E5A300BFC163 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
When using cocoapods 1.2, this is needed for objective-c projects where Always Embed Swift Standard Libraries is set to $(inherited)