### PR TITLE
Add support for using PermissionScope as Settings

### DIFF
--- a/PermissionScope/PermissionScope.swift
+++ b/PermissionScope/PermissionScope.swift
@@ -1022,7 +1022,7 @@ typealias resultsForConfigClosure     = ([PermissionResult]) -> Void
     /**
     Creates the modal viewcontroller and shows it.
     */
-    fileprivate func showAlert() {
+    public func showAlert() {
         // add the backing views
         let window = UIApplication.shared.keyWindow!
         


### PR DESCRIPTION
Making `showAlert` public, allows you to force the dialog to open.

This opens the library to the following use-case:
* Open a settings window where the user can accept, deny or change previously configured permissions by calling addPermission on all used permissions.